### PR TITLE
Added React Sketchapp Starter Kit

### DIFF
--- a/generator/starterProjectUrls.js
+++ b/generator/starterProjectUrls.js
@@ -76,6 +76,7 @@ module.exports = [
   'https://github.com/kriasoft/babel-starter-kit',
   'https://github.com/kriasoft/react-starter-kit',
   'https://github.com/kriasoft/react-static-boilerplate',
+  'https://github.com/kristinbaumann/react-sketchapp-starter-kit',
   'https://github.com/KyleAMathews/coffee-react-quickstart',
   'https://github.com/LEINWAND/react-redux-app',
   'https://github.com/lubien/koa-react-redux-universal-boilerplate',


### PR DESCRIPTION
React can be used together with Sketch to render code to design. This React Sketchapp Starter Kit includes the simplest version of getting such a project running.
