### PR TITLE
Add Typescript Webpack Starter

### DIFF
--- a/generator/starterProjectUrls.js
+++ b/generator/starterProjectUrls.js
@@ -45,6 +45,7 @@ module.exports = [
   'https://github.com/dvajs/dva',
   'https://github.com/eanplatter/react-starter',
   'https://github.com/elierotenberg/react-rails-starterkit',
+  'https://github.com/emyann/typescript-webpack-starter'
   'https://github.com/ericelliott/react-pure-component-starter',
   'https://github.com/erikras/react-redux-universal-hot-example',
   'https://github.com/este/este',


### PR DESCRIPTION
Asciinema record: https://asciinema.org/a/130219 
A Starter Kit and a CLI to create your TypeScript / ES6 module bundled by Webpack without thinking about build or unit tests configurations.

Thank you 🙏🏽